### PR TITLE
fix: double paste inside webviews

### DIFF
--- a/index.html
+++ b/index.html
@@ -256,6 +256,29 @@
         event.preventDefault();
       }
     });
+
+
+    // fix double-pasting inside webviews
+    function handleInnerWebviewPaste(webview) {
+      webview.addEventListener('dom-ready', function () {
+        webview.executeJavaScript(`
+      let pasted = false;
+      window.addEventListener('paste', function(event) {
+          if (pasted) {
+              event.preventDefault();
+              pasted = false;
+          } else {
+              pasted = true;
+          }
+      });
+    `);
+      });
+    }
+
+    handleInnerWebviewPaste(webviewOAI);
+    handleInnerWebviewPaste(webviewBARD);
+    handleInnerWebviewPaste(webviewCLAUDE);
+
   </script>
 </body>
 


### PR DESCRIPTION
issue: pasting text into the inner webview would result in the text appearing twice. this was due to electron's handling of paste events in webviews which under certain conditions might trigger the event twice

to circumvent this a flag has been introduced to intercept and ignore every second paste event

https://github.com/smol-ai/menubar/assets/90765930/d603c75f-4cfd-431e-8e0b-2fd123cfebb3

