### PR TITLE
fix: debounce inner paste event

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,14 +262,18 @@
     function handleInnerWebviewPaste(webview) {
       webview.addEventListener('dom-ready', function () {
         webview.executeJavaScript(`
-      let pasted = false;
+      let lastPastedText = null;
+      let lastPasteTime = 0;
       window.addEventListener('paste', function(event) {
-          if (pasted) {
-              event.preventDefault();
-              pasted = false;
-          } else {
-              pasted = true;
-          }
+        const currentTime = Date.now();
+        const clipboardData = event.clipboardData || window.clipboardData;
+        const pastedText = clipboardData.getData('text');
+        if (lastPastedText === pastedText && currentTime - lastPasteTime < 100) {
+          event.preventDefault();
+        } else {
+          lastPastedText = pastedText;
+          lastPasteTime = currentTime;
+        }
       });
     `);
       });


### PR DESCRIPTION
issue: looks like the paste event was getting triggered more than twice for some users
this PR debounces these events, ensuring only one paste of the same text occurs within 100ms