### PR TITLE
fix: duplicate paste proper fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -269,29 +269,26 @@
 
 
     // fix double-pasting inside webviews
-    function handleInnerWebviewPaste(webview) {
+    function setupCustomPasteBehavior(webview) {
       webview.addEventListener('dom-ready', function () {
         webview.executeJavaScript(`
-      let lastPastedText = null;
-      let lastPasteTime = 0;
-      window.addEventListener('paste', function(event) {
-        const currentTime = Date.now();
-        const clipboardData = event.clipboardData || window.clipboardData;
-        const pastedText = clipboardData.getData('text');
-        if (lastPastedText === pastedText && currentTime - lastPasteTime < 300) {
-          event.preventDefault();
-        } else {
-          lastPastedText = pastedText;
-          lastPasteTime = currentTime;
-        }
+    document.addEventListener('paste', (event) => {
+              event.preventDefault();
+      let text = event.clipboardData.getData('text');
+      let activeElement = document.activeElement;
+      let start = activeElement.selectionStart;
+      let end = activeElement.selectionEnd;
+      activeElement.value = activeElement.value.slice(0, start) + text + activeElement.value.slice(end);
+      activeElement.selectionStart = activeElement.selectionEnd = start + text.length;
       });
     `);
       });
     }
 
-    handleInnerWebviewPaste(webviewOAI);
-    handleInnerWebviewPaste(webviewBARD);
-    handleInnerWebviewPaste(webviewCLAUDE);
+    setupCustomPasteBehavior(webviewOAI);
+    setupCustomPasteBehavior(webviewBARD);
+    setupCustomPasteBehavior(webviewCLAUDE);
+
 
   </script>
 </body>

--- a/index.js
+++ b/index.js
@@ -207,7 +207,7 @@ app.on("ready", () => {
         const { control, meta, key } = input;
         if (!control && !meta) return;
         if (key === "c") contents.copy();
-        if (key === "v") contents.paste();
+        // if (key === "v") contents.paste(); // we will handle this manually
         if (key === "a") contents.selectAll();
         if (key === "z") contents.undo();
         if (key === "y") contents.redo();


### PR DESCRIPTION
issue: The application's WebView instances were triggering the 'paste' event more than once when the user attempted to paste text. This occurred because both Electron and the web content inside the WebView were handling the paste event, causing duplicate actions

solution:

- removed Electron's 'paste' action listener from WebView instances in the main process. By commenting out the line 
`if (key === "v") contents.paste()` 
we stopped Electron from handling paste events at the application level.

- injected JavaScript into each WebView to capture the 'paste' event before it reaches Electron. This JavaScript prevents the default paste behavior, extracts the pasted text from the ClipboardData object, and pastes it manually into the focused element


https://github.com/smol-ai/menubar/assets/90765930/a3cdd097-93f1-4c32-bda8-799e6a960739

