### PR TITLE
Add option to use "Enter" key instead of "CMD+Enter" keys in super prompt

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,9 +38,16 @@
     // add event listener for btn
     const promptEl = document.getElementById('prompt');
     // Submit prompt when the user presses Enter or Ctrl+Enter in the textarea input
+    const SuperPromptEnterKey = store.get('SuperPromptEnterKey', true);
     promptEl.addEventListener("keydown", function (event) {
-      if (event.keyCode === 13 && (event.metaKey || event.ctrlKey)) {
-        document.getElementById('btn').click();
+      if (SuperPromptEnterKey) {
+        if (event.keyCode === 13) {
+          document.getElementById('btn').click();
+        } else {
+          if (event.keyCode === 13 && (event.metaKey || event.ctrlKey)) {
+            document.getElementById('btn').click();
+          }
+        }
       }
     });
     promptEl.addEventListener('input', function (event) {

--- a/preferences.html
+++ b/preferences.html
@@ -26,6 +26,11 @@
         <input type="checkbox" id="webviewCLAUDEEnabled" checked>
         Enable Anthropic Claude
     </label>
+    <br>
+    <label>
+        <input type="checkbox" id="SuperPromptEnterKey" checked>
+        Enable Super Prompt "Enter" key only instead of "CMD+Enter" Keys
+    </label>
     <br /><br />
     <button id="save">Save</button>
     <script src="preferences.js"></script>

--- a/preferences.js
+++ b/preferences.js
@@ -4,6 +4,7 @@ const store = new Store();
 document.getElementById('webviewOAIEnabled').checked = store.get('webviewOAIEnabled', true);
 document.getElementById('webviewBARDEnabled').checked = store.get('webviewBARDEnabled', true);
 document.getElementById('webviewCLAUDEEnabled').checked = store.get('webviewCLAUDEEnabled', true);
+document.getElementById('SuperPromptEnterKey').checked = store.get('SuperPromptEnterKey', true);
 
 document.getElementById('webviewOAIEnabled').addEventListener('change', (event) => {
     store.set('webviewOAIEnabled', event.target.checked);
@@ -17,6 +18,10 @@ document.getElementById('webviewCLAUDEEnabled').addEventListener('change', (even
     store.set('webviewCLAUDEEnabled', event.target.checked);
 });
 
+document.getElementById('SuperPromptEnterKey').addEventListener('change', (event) => {
+    store.set('SuperPromptEnterKey', event.target.checked);
+});
+
 document.getElementById('save').addEventListener('click', () => {
 
     console.log('save clicked');
@@ -25,9 +30,11 @@ document.getElementById('save').addEventListener('click', () => {
     const webviewOAIEnabled = document.getElementById('webviewOAIEnabled').checked;
     const webviewBARDEnabled = document.getElementById('webviewBARDEnabled').checked;
     const webviewCLAUDEEnabled = document.getElementById('webviewCLAUDEEnabled').checked;
+    const SuperPromptEnterKey = document.getElementById('SuperPromptEnterKey').checked;
     store.set('webviewOAIEnabled', webviewOAIEnabled);
     store.set('webviewBARDEnabled', webviewBARDEnabled);
     store.set('webviewCLAUDEEnabled', webviewCLAUDEEnabled);
+    store.set('SuperPromptEnterKey', SuperPromptEnterKey);
 
     // Close the preferences window
     window.close();


### PR DESCRIPTION
In previous versions, I found it convenient to only use the "Enter" key in the super prompt. I'm adding an option to allow users to use either the "Enter" key or "CMD+Enter" keys in the super prompt.