### PR TITLE
Dark mode and CSS cleanup for claude, bing, and chatGPT

### DIFF
--- a/providers/bing.js
+++ b/providers/bing.js
@@ -54,20 +54,11 @@ class Bing extends Provider {
 		`);
 	}
 
+	/** Bing requires MS Edge user agent. */
 	static getUserAgent() {
 		return 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.37'
 	}
 
-	/**
-	 * Bing has a lot of nested shadow DOMs, so we have to use JS to access the
-	 * elements we want to hide / style.
-	 *
-	 * FIXME: Still can't seem to get this working yet. There might be some funny
-	 * scripts running in the background that are resetting styles.
-	 *
-	 * Thankfully, the event listeners are still working for input and submit, so
-	 * we can still send prompts to the chatbot.
-	 */
 	static handleCss() {
     // this.webview.executeJavaScript(`
 		// 		// Hide Header Bar
@@ -113,6 +104,21 @@ class Bing extends Provider {
 				}
         `);
 			}, 1000);
+			setTimeout(() => {
+				this.getWebview().insertJavaScript(`
+					// Access SERP Shadow DOM
+					var serpDOM = document.querySelector('.cib-serp-main').shadowRoot;
+
+					// Conversation Shadow DOM
+					var conversationDOM = serpDOM.querySelector('#cib-conversation-main').shadowRoot;
+
+					// Welcome Container Shadow DOM
+					var welcomeDOM = conversationDOM.querySelector('cib-welcome-container').shadowRoot;
+					console.log('🔴 welcomeDOM', welcomeDOM);
+					welcomeDOM.querySelector('div.preview-container').setAttribute('style', 'display: none !important');
+
+				`);
+			}, 2000);
 		});
 	}
 

--- a/providers/bing.js
+++ b/providers/bing.js
@@ -60,35 +60,13 @@ class Bing extends Provider {
 	}
 
 	static handleCss() {
-    // this.webview.executeJavaScript(`
-		// 		// Hide Header Bar
-		// 		var headerBar = document.querySelector('header');
-		// 		headerBar.remove();
-
-    //     // // Access SERP Shadow DOM
-    //     // var serpDOM = document.querySelector('.cib-serp-main').shadowRoot;
-
-    //     // // Conversation Shadow DOM
-    //     // var conversationDOM = serpDOM.querySelector('#cib-conversation-main').shadowRoot;
-
-    //     // // Welcome Container Shadow DOM
-    //     // var welcomeDOM = conversationDOM.querySelector('cib-welcome-container').shadowRoot;
-		// 		// console.log('welcomeDOM', welcomeDOM);
-
-    //     // // Hide all welcome container items except tone selector
-    //     // welcomeDOM.querySelector('div.container-logo').setAttribute('style', 'display: none !important');
-    //     // welcomeDOM.querySelector('div.container-title').setAttribute('style', 'display: none !important');
-    //     // welcomeDOM.querySelector('div.container-subTitle').setAttribute('style', 'display: none !important');
-    //     // welcomeDOM.querySelector('div.container-item').setAttribute('style', 'display: none !important');
-    //     // welcomeDOM.querySelector('div.learn-tog-item').setAttribute('style', 'display: none !important');
-    //     // welcomeDOM.querySelector('div.privacy-statement').setAttribute('style', 'display: none !important');
-    // }`);
 		this.getWebview().addEventListener('dom-ready', () => {
 			// hide message below text input, sidebar, suggestions on new chat
 			setTimeout(() => {
 				this.getWebview().insertCSS(`
 				html, body {
 					overflow: hidden;
+					scrollbar-width: none;
 				}
 				#b_sydBgCover {
 					background: black !important;
@@ -105,7 +83,7 @@ class Bing extends Provider {
         `);
 			}, 1000);
 			setTimeout(() => {
-				this.getWebview().insertJavaScript(`
+				this.getWebview().executeJavaScript(`
 					// Access SERP Shadow DOM
 					var serpDOM = document.querySelector('.cib-serp-main').shadowRoot;
 
@@ -114,8 +92,17 @@ class Bing extends Provider {
 
 					// Welcome Container Shadow DOM
 					var welcomeDOM = conversationDOM.querySelector('cib-welcome-container').shadowRoot;
-					console.log('🔴 welcomeDOM', welcomeDOM);
-					welcomeDOM.querySelector('div.preview-container').setAttribute('style', 'display: none !important');
+
+					// Hide all welcome container items except tone selector
+					// welcomeDOM.querySelector('div.preview-container').setAttribute('style', 'display: none !important;');
+
+					// Hide all welcome container items except tone selector
+					welcomeDOM.querySelector('div.container-logo').setAttribute('style', 'display: none !important');
+					welcomeDOM.querySelector('div.container-title').setAttribute('style', 'display: none !important');
+					welcomeDOM.querySelector('div.container-subTitle').setAttribute('style', 'display: none !important');
+					welcomeDOM.querySelector('div.container-item').setAttribute('style', 'display: none !important');
+					welcomeDOM.querySelector('div.learn-tag-item').setAttribute('style', 'display: none !important');
+					welcomeDOM.querySelector('div.privacy-statement').setAttribute('style', 'display: none !important');
 
 				`);
 			}, 2000);

--- a/providers/bing.js
+++ b/providers/bing.js
@@ -96,8 +96,20 @@ class Bing extends Provider {
 			// hide message below text input, sidebar, suggestions on new chat
 			setTimeout(() => {
 				this.getWebview().insertCSS(`
+				html, body {
+					overflow: hidden;
+				}
 				#b_sydBgCover {
 					background: black !important;
+				}
+				header {
+					display: none !important;
+				}
+				#b_sydWelcomeTemplate {
+					display: none !important;
+				}
+				.preview-container {
+					display: none !important;
 				}
         `);
 			}, 1000);

--- a/providers/bing.js
+++ b/providers/bing.js
@@ -104,8 +104,9 @@ class Bing extends Provider {
 					welcomeDOM.querySelector('div.learn-tag-item').setAttribute('style', 'display: none !important');
 					welcomeDOM.querySelector('div.privacy-statement').setAttribute('style', 'display: none !important');
 
+					serpDOM.querySelector('cib-serp-feedback').setAttribute('style', 'display: none !important');
 				`);
-			}, 2000);
+			}, 1000);
 		});
 	}
 

--- a/providers/bing.js
+++ b/providers/bing.js
@@ -68,6 +68,10 @@ class Bing extends Provider {
 					overflow: hidden;
 					scrollbar-width: none;
 				}
+				body {
+					background-color: #1d1d1d !important;
+					color: #d7d7d7 !important;
+				}
 				#b_sydBgCover {
 					background: black !important;
 				}
@@ -90,6 +94,12 @@ class Bing extends Provider {
 					// Conversation Shadow DOM
 					var conversationDOM = serpDOM.querySelector('#cib-conversation-main').shadowRoot;
 
+					// Action Bar Shadow DOM
+					var actionBarDOM = serpDOM.querySelector('#cib-action-bar-main').shadowRoot;
+
+					// Text Input Shadow DOM
+					var textInputDOM = actionBarDOM.querySelector('cib-text-input').shadowRoot;
+
 					// Welcome Container Shadow DOM
 					var welcomeDOM = conversationDOM.querySelector('cib-welcome-container').shadowRoot;
 
@@ -104,7 +114,18 @@ class Bing extends Provider {
 					welcomeDOM.querySelector('div.learn-tag-item').setAttribute('style', 'display: none !important');
 					welcomeDOM.querySelector('div.privacy-statement').setAttribute('style', 'display: none !important');
 
+					// Remove feedback widget
 					serpDOM.querySelector('cib-serp-feedback').setAttribute('style', 'display: none !important');
+
+					// Remove background gradients
+					serpDOM.querySelector('cib-background').remove();
+					conversationDOM.querySelector('.fade.top').remove();
+					conversationDOM.querySelector('.fade.bottom').remove();
+
+					// Recolor text input
+					textInputDOM.querySelector('textarea').setAttribute('style', 'background-color: #1d1d1d !important; color: #d7d7d7 !important;');
+					actionBarDOM.querySelector('.main-container.body-2').setAttribute('style', 'background-color: #1d1d1d !important; color: #d7d7d7 !important;');
+
 				`);
 			}, 1000);
 		});

--- a/providers/bing.js
+++ b/providers/bing.js
@@ -108,7 +108,7 @@ class Bing extends Provider {
 
 					// Hide all welcome container items except tone selector
 					welcomeDOM.querySelector('div.container-logo').setAttribute('style', 'display: none !important');
-					welcomeDOM.querySelector('div.container-title').setAttribute('style', 'display: none !important');
+					welcomeDOM.querySelector('div.container-title').setAttribute('style', 'color: white !important');
 					welcomeDOM.querySelector('div.container-subTitle').setAttribute('style', 'display: none !important');
 					welcomeDOM.querySelector('div.container-item').setAttribute('style', 'display: none !important');
 					welcomeDOM.querySelector('div.learn-tag-item').setAttribute('style', 'display: none !important');

--- a/providers/claude2.js
+++ b/providers/claude2.js
@@ -34,25 +34,6 @@ class Claude2 extends Provider {
 				/* black background */
 				body {
 					background-color: #1d1d1d !important;
-					color: #d7d7d7 !important;
-				}
-				/* reset text colors for user input and history displays */
-				fieldset {
-					color: black !important;
-				}
-				div[cmdk-group-items] {
-					color: black !important;
-				}
-
-				/* messages */
-				.text-stone-900.bg-white {
-					background-color: #1d1d1d !important;
-					color: #d7d7d7 !important;
-				}
-
-        header, .container {
-          background-color: white;
-          /* single line dark mode ftw */
           filter: invert(100%) hue-rotate(180deg);
         }
         /* hide the claude avatar in response */
@@ -64,48 +45,6 @@ class Claude2 extends Provider {
           margin: 0 !important;
         }
 
-				body {
-					background-color: #1e1e1e;
-					color: #fff;
-				}
-
-				/* Dark input field */
-				fieldset {
-					background-color: #222 !important;
-					color: white !important;
-					border-radius: 0px;
-				}
-				/* Placeholder text */
-				.ProseMirror[data-placeholder]:before {
-					color: #6c757d !important;
-				}
-
-				/* Input text */
-				.ProseMirror {
-					color: white !important;
-				}
-
-				/* Attachment button */
-				label {
-					background-color: #1d1d1d !important;
-				}
-				label]:hover {
-					background-color: #444 !important;
-				}
-
-				/* Simplify and set to dark mode the chat history on initial prompt */
-				div[role="listbox"] div[cmdk-item] {
-					background-color: #222;
-					color:white;
-					border: 0px;
-					border-radius: 0px;
-				}
-				.shadow-element {
-					box-shadow: none !important;
-				}
-				div[role="listbox"] div[cmdk-item]:hover {
-					background-color: #444;
-				}
         `);
 			}, 1000);
 			setTimeout(() => {

--- a/providers/claude2.js
+++ b/providers/claude2.js
@@ -105,7 +105,7 @@ class Claude2 extends Provider {
 				}
 				div[role="listbox"] div[cmdk-item]:hover {
 					background-color: #444;
-				}˝
+				}
         `);
 			}, 1000);
 		});

--- a/providers/claude2.js
+++ b/providers/claude2.js
@@ -43,7 +43,7 @@ class Claude2 extends Provider {
 				div[cmdk-group-items] {
 					color: black !important;
 				}
-				
+
 				/* messages */
 				.text-stone-900.bg-white {
 					background-color: #1d1d1d !important;
@@ -63,6 +63,49 @@ class Claude2 extends Provider {
         .mx-4.md\:mx-12.mb-2.md\:mb-4.mt-2.w-auto {
           margin: 0 !important;
         }
+
+				body {
+					background-color: #1e1e1e;
+					color: #fff;
+				}
+
+				/* Dark input field */
+				fieldset {
+					background-color: #222 !important;
+					color: white !important;
+					border-radius: 0px;
+				}
+				/* Placeholder text */
+				.ProseMirror[data-placeholder]:before {
+					color: #6c757d !important;
+				}
+
+				/* Input text */
+				.ProseMirror {
+					color: white !important;
+				}
+
+				/* Attachment button */
+				label {
+					background-color: #1d1d1d !important;
+				}
+				label]:hover {
+					background-color: #444 !important;
+				}
+
+				/* Simplify and set to dark mode the chat history on initial prompt */
+				div[role="listbox"] div[cmdk-item] {
+					background-color: #222;
+					color:white;
+					border: 0px;
+					border-radius: 0px;
+				}
+				.shadow-element {
+					box-shadow: none !important;
+				}
+				div[role="listbox"] div[cmdk-item]:hover {
+					background-color: #444;
+				}˝
         `);
 			}, 1000);
 		});

--- a/providers/claude2.js
+++ b/providers/claude2.js
@@ -108,6 +108,12 @@ class Claude2 extends Provider {
 				}
         `);
 			}, 1000);
+			setTimeout(() => {
+				this.getWebview().executeJavaScript(`
+				// hide welcome back title
+				document.querySelector('h2').style.display = 'none';
+				`);
+			}, 1000);
 		});
 	}
 

--- a/providers/openai.js
+++ b/providers/openai.js
@@ -39,7 +39,10 @@ class OpenAi extends Provider {
 		this.getWebview().addEventListener('dom-ready', () => {
 			// hide message below text input, sidebar, suggestions on new chat
 			this.getWebview().insertCSS(`
-          .text-xs.text-center {
+        body {
+          scrollbar-width: none;
+        }
+        .text-xs.text-center {
             opacity: 0;
             height: 0;
             margin-bottom: -10px;

--- a/providers/openai.js
+++ b/providers/openai.js
@@ -62,6 +62,19 @@ class OpenAi extends Provider {
 
 
         `);
+        setTimeout(() => {
+          this.getWebview().executeJavaScript(`
+          // Get the root element
+          const root = document.querySelector(':root');
+
+          // Set the color-scheme CSS variable
+          root.style.setProperty('--color-scheme', 'dark');
+
+          // Add the .dark class to the body
+          document.body.classList.add('dark');
+
+          `);
+        }, 0);
 		});
 	}
 


### PR DESCRIPTION
This PR:
- Forces Chat GPT into dark mode
- Does CSS changes to create a dark mode for bing and Claude 2
- Deletes some unnecessary UI clutter from Claude and Bing

Much better experience on smaller screens now imo! Please take a look and merge if you agree!