### PR TITLE
add support for fullscreen toggle + keyboard shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 👼 smol menubar
 
-This is a smol menubar app that helps you quickly access **the full webapps** of ChatGPT (defaults to "[GPT4.5](https://www.latent.space/p/code-interpreter#details)"!!), Bing and Anthropic Claude 2 with a single keyboard shortcut (Cmd+Shift+G). 
+This is a smol menubar app that helps you quickly access **the full webapps** of ChatGPT (defaults to "[GPT4.5](https://www.latent.space/p/code-interpreter#details)"!!), Bing and Anthropic Claude 2 with a single keyboard shortcut (Cmd+Shift+G).
 
 > we also support Bard, Claude 1, and local models like LLaMA and Vicuna (via [OobaBooga](https://github.com/oobabooga/text-generation-webui)) but hide by default bc they aren't as good!
 
@@ -21,12 +21,28 @@ Yes and no:
 
 ## Features and Usage
 
-- **Keyboard Shortcut**: I usually just always press Cmd+Shift+G -> quick open to use it and Cmd+Enter to submit. 
-   - You can modify these keyboard shortcuts if you build it from source.
-- **Resize**: You can resize the overall window with a click n drag. Cmd+1/2/3/A/+/- or drag to resize the internal webviews as you wish.
-- **Toggle Models**: You can also enable/disable models from the preferences modal and your choice is persisted. We support ChatGPT, Bing, Bard, Claude 1/2.
-  - NEW: We have added initial support for https://github.com/oobabooga/text-generation-webui. You'll have to go thru their process, including downloading their models ([I use LLaMa-13B-GGML](https://huggingface.co/TheBloke/LLaMa-13B-GGML/blob/main/llama-13b.ggmlv3.q4_0.bin)) and get it running for yourself on http://127.0.0.1:7860/, before you can run it inside of smol menubar (since we just embed the UI). It only allows one kind of prompt template now, and **would take a PR** if you can figure out how to make the templating customizable (see the Oobabooga.js provider)
-- **New Chats**: To start a new conversation, cmd+R (simple window refresh, nothing special)
+- **Keyboard Shortcuts**:
+  - Use `Cmd+Shift+G` for quick open and `Cmd+Enter` to submit.
+  - Customize these shortcuts by building from source.
+
+- **Window Resizing**:
+  - Resize the window by clicking and dragging.
+  - Use `Cmd+Shift+F` to set the width to 100% of your screen.
+  - Use `Cmd+1/2/3/A/+/-` or drag to resize the internal webviews.
+
+- **Model Toggle**:
+  - Enable/disable providers by accessing the context menu from the menubar icon (right-click and choose from the list). The choice is saved for future sessions.
+  - Supported models: ChatGPT, Bing, Bard, Claude 1/2.
+
+- **Support for oobabooga/text-generation-webui**:
+  - Initial support for [oobabooga/text-generation-webui](https://github.com/oobabooga/text-generation-webui) has been added.
+  - Users need to follow the process outlined in the text-generation-webui repository, including downloading models (e.g. [LLaMa-13B-GGML](https://huggingface.co/TheBloke/LLaMa-13B-GGML/blob/main/llama-13b.ggmlv3.q4_0.bin)).
+  - Run the model on `http://127.0.0.1:7860/` before running it inside of the smol menubar.
+  - The UI only supports one kind of prompt template. Contributions are welcome to make the templating customizable (see the Oobabooga.js provider).
+
+- **Starting New Conversations**:
+  - Use `Cmd+R` to start a new conversation with a simple window refresh.
+
 
 ## video demo
 
@@ -43,9 +59,9 @@ You can download the precompiled binaries for MacOS: https://github.com/smol-ai/
 
 The first run creates a desktop shortcut. After the initial setup, you can simply use the generated desktop file to start the application in the future.
 
-When you first run the app: 
+When you first run the app:
 
-1. log into your Google account (once you log into your google account for chatgpt, you'l also be logged in to Bard). 
+1. log into your Google account (once you log into your google account for chatgpt, you'l also be logged in to Bard).
 2. For Bing, after you log in to your Microsoft account, you'll need to refresh to get into the Bing Chat screen. It's a little finnicky at first try but it works.
 3. Login for Anthropic via Google SSO is broken right now - it requires a popup which is blocked at least in my testing. For now just use manual email + login token, it works fine (dont include the extra space at the end from their email!!). If you are familiar with Electron and Webviews, would welcome a PR to fix, we can't figure it out so far.
 


### PR DESCRIPTION
I noticed that I'm spending a lot of time dragging to resize the menubar to make it fullscreen. With this small update, you can hit `Cmd` + `Shift` + `F` (which is conveniently right next to `Cmd` + `Shift` + `G`!) to toggle back and forth between full viewport width and the default 1200 pixel width.

Great for people on ultra-wide monitors, you can probably now easily fit 6 or 7 providers side-by-side.

This demo video shows it on my laptop screen but I can take another one on my super-wide monitor when I get a chance if we think it's worth sharing!

https://github.com/smol-ai/menubar/assets/882952/21056599-4657-4a25-b622-252a3b7654a7

