### PR TITLE
Dont show dock icon

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ app.on('ready', () => {
 			height: 750,
 		},
 		tray,
-		showOnAllWorkspaces: true,
+		showOnAllWorkspaces: false,
 		preloadWindow: true,
 		showDockIcon: false,
 		icon: image,


### PR DESCRIPTION
As per the discussion on [here](https://github.com/maxogden/menubar/issues/306), this change hides the dock icon. I made the change locally, build the app and it's working!