### PR TITLE
Better styling for the superprompt bar

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,3 +1,9 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
     Arial, sans-serif;
@@ -62,7 +68,7 @@ body {
 }
 #form textarea {
   width: 100%;
-  height: 80px;
+  height: 100%;
   resize: none;
   overflow-y: auto; /* Adds a scrollbar when the content is too big */
   padding: 0 12px;
@@ -70,11 +76,20 @@ body {
   outline: none;
   background-color: bisque;
   flex-grow: 1;
+  border-radius: 5px;
+  border: 0;
+  transition: background-color 0.3s ease-in-out;
+}
+
+#form textarea:focus {
+  background-color: #fff;
 }
 
 #form button {
-  margin: 0 4px;
+  margin-left: 4px;
   padding: 0 12px;
+  border-radius: 5px;
+  border: 1px solid rgba(0, 0, 0, 0.2);
 }
 
 webview {

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ app.on('ready', () => {
 			height: 750,
 		},
 		tray,
-		showOnAllWorkspaces: true,
+		showOnAllWorkspaces: false,
 		preloadWindow: true,
 		showDockIcon: false,
 		icon: image,


### PR DESCRIPTION
Something that was bothering me is that the windows were rounded but the prompt bar was not so I changed that. Also
- prompt bar changes color when in focus. @swyxio feel free to change the color
- The margin between the left hand side and the right hand side of the prompt bar is now equal (box sizing border box lol)

If you want I can implement the design from #24 entirely

<img width="1509" alt="image" src="https://github.com/smol-ai/menubar/assets/2018374/8db98b60-6c05-454e-ba7f-06670cd7a5d8">
