### PR TITLE
Design upgrade for superprompt bar

### DIFF
--- a/index.css
+++ b/index.css
@@ -43,12 +43,14 @@ body {
 }
 
 .page {
+  --superprompt-height: 100px;
+  
   background: #eeeeee;
   /* overflow: auto; */
   /* disabled because its quite buggy */
   /* resize: both;  */
   width: 100%;
-  height: calc(100vh - 12px - 80px);
+  height: calc(100vh - 12px - var(--superprompt-height));
   margin-top: 12px;
   margin: 0 auto;
   position: relative;
@@ -61,35 +63,50 @@ body {
 }
 
 #form {
-  height: 80px;
+  height: var(--superprompt-height);
   width: 100%;
   display: flex;
-  padding: 5px;
+  align-items: center;
+  border: 1px solid black;
+  margin-top: 8px;
+  border-radius: 10px;
+  overflow: hidden;
+  background-color: #eee;
 }
+
+#form:focus-within {
+  background-color: #fff;
+}
+
 #form textarea {
   width: 100%;
   height: 100%;
   resize: none;
   overflow-y: auto; /* Adds a scrollbar when the content is too big */
-  padding: 0 12px;
+  padding: 4px 12px;
   font-size: 16px;
   outline: none;
-  background-color: bisque;
   flex-grow: 1;
   border-radius: 5px;
   border: 0;
-  transition: background-color 0.3s ease-in-out;
+  background-color: transparent;
 }
 
-#form textarea:focus {
-  background-color: #fff;
-}
 
 #form button {
   margin-left: 4px;
-  padding: 0 12px;
+  margin-right: 8px;
+  padding: 6px 12px;
   border-radius: 5px;
   border: 1px solid rgba(0, 0, 0, 0.2);
+  background: black;
+  color: rgba(255, 255, 255, 0.7);
+  transition: all 0.1s ease;
+  cursor: pointer;
+}
+
+#form button:hover {
+  color: rgba(255, 255, 255, 0.9);
 }
 
 webview {
@@ -98,7 +115,7 @@ webview {
   top: 0;
   left: 0;
   width: 100%;
-  height: calc(100vh - 12px - 80px);
+  height: calc(100vh - 12px - var(--superprompt-height));
   display: inline-flex !important;
 }
 

--- a/index.css
+++ b/index.css
@@ -1,3 +1,9 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
     Arial, sans-serif;
@@ -62,7 +68,7 @@ body {
 }
 #form textarea {
   width: 100%;
-  height: 80px;
+  height: 100%;
   resize: none;
   overflow-y: auto; /* Adds a scrollbar when the content is too big */
   padding: 0 12px;
@@ -70,11 +76,20 @@ body {
   outline: none;
   background-color: bisque;
   flex-grow: 1;
+  border-radius: 5px;
+  border: 0;
+  transition: background-color 0.3s ease-in-out;
+}
+
+#form textarea:focus {
+  background-color: #fff;
 }
 
 #form button {
-  margin: 0 4px;
+  margin-left: 4px;
   padding: 0 12px;
+  border-radius: 5px;
+  border: 1px solid rgba(0, 0, 0, 0.2);
 }
 
 webview {

--- a/index.css
+++ b/index.css
@@ -96,17 +96,26 @@ body {
 #form button {
   margin-left: 4px;
   margin-right: 8px;
-  padding: 6px 12px;
   border-radius: 5px;
   border: 1px solid rgba(0, 0, 0, 0.2);
   background: black;
   color: rgba(255, 255, 255, 0.7);
   transition: all 0.1s ease;
   cursor: pointer;
+  display: flex;
 }
 
-#form button:hover {
-  color: rgba(255, 255, 255, 0.9);
+#form svg {
+  stroke: white;
+  width: 20px;
+  height: 20px;
+  margin: 0.5rem;
+  transform: rotate(-30deg) translateY(-2px) translateX(2px);
+  transition: all 0.1s ease;
+}
+
+#form button:hover svg {
+  stroke: rgba(255, 255, 255, 0.8);
 }
 
 webview {

--- a/index.html
+++ b/index.html
@@ -19,7 +19,11 @@
 - Resize windows: Cmd+1/2/3/A/-/+
 - New chat: Cmd+R
       "></textarea>
-    <button id="btn" type="submit">Cmd+Enter <br> to Submit</button>
+    <button id="btn" type="submit" title="cmd+enter to submit">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 12L3.269 3.126A59.768 59.768 0 0121.485 12 59.77 59.77 0 013.27 20.876L5.999 12zm0 0h7.5" />
+      </svg>
+    </button>
   </form>
   <script src="interface.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
 - Resize windows: Cmd+1/2/3/A/-/+
 - New chat: Cmd+R
       "></textarea>
-    <button id="btn" type="submit">Cmd+Enter to Submit</button>
+    <button id="btn" type="submit">Cmd+Enter <br> to Submit</button>
   </form>
   <script src="interface.js"></script>
 </body>

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ app.on('ready', () => {
 			height: 750,
 		},
 		tray,
-		showOnAllWorkspaces: true,
+		showOnAllWorkspaces: false,
 		preloadWindow: true,
 		showDockIcon: false,
 		icon: image,

--- a/interface.js
+++ b/interface.js
@@ -50,6 +50,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
 // Get the textarea input element for the prompt
 const promptEl = document.getElementById('prompt');
+promptEl.focus()
 
 // Get the key binding for submitting the prompt from the store
 const SuperPromptEnterKey = store.get('SuperPromptEnterKey', false);


### PR DESCRIPTION
- An implementation of #24 
- I took inspiration that the menubar menu gives an easy way to toggle sites on and off so didn't implement the tabs. Most of the time I wanna see the output and the tabs would take up space
- The arrow icon would make it less intuitive that cmd+enter submits the query so I kept the text as is.

<img width="1312" alt="image" src="https://github.com/smol-ai/menubar/assets/2018374/65befc1c-3e95-4781-b212-011f2b382127">
