### PR TITLE
feature - add dark mode toggle to context menu [WIP]

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,6 +186,18 @@ app.on('ready', () => {
 				},
 			];
 
+			const darkModeToggle = {
+				label: 'Toggle Dark Mode',
+				type: 'checkbox',
+				checked: store.get('darkMode', false),
+				click: () => {
+					store.set('darkMode', !store.get('darkMode', false));
+					setTimeout(() => {
+						window.reload();
+					}, 100);
+				},
+			};
+
 			const separator = { type: 'separator' };
 
 			const providersToggles = allProviders.map((provider) => {
@@ -248,6 +260,7 @@ app.on('ready', () => {
 			// Return the complete context menu template
 			return [
 				...menuHeader,
+				darkModeToggle,
 				superPromptEnterKey, // TODO: move into the customize keyboard shortcut window
 				separator,
 				...providersToggles,

--- a/index.js
+++ b/index.js
@@ -188,6 +188,7 @@ app.on('ready', () => {
 
 			const darkModeToggle = {
 				label: 'Toggle Dark Mode',
+				accelerator: 'CommandorControl+Shift+L',
 				type: 'checkbox',
 				checked: store.get('darkMode', false),
 				click: () => {

--- a/interface.js
+++ b/interface.js
@@ -48,6 +48,22 @@ window.addEventListener('DOMContentLoaded', () => {
 });
 
 /* ========================================================================== */
+/* Dark Mode Listeners                                                        */
+/* ========================================================================== */
+
+// Get the initial value of isDarkMode from the store
+ipcRenderer.invoke('getStoreValue', 'isDarkMode').then((isDarkMode) => {
+    enabledProviders.forEach((provider) => provider.toggleDarkMode(isDarkMode));
+});
+
+// Listen for changes to the isDarkMode value in the store
+ipcRenderer.on('setStoreValue', (event, key, value) => {
+    if (key === 'isDarkMode') {
+        enabledProviders.forEach((provider) => provider.toggleDarkMode(value));
+    }
+});
+
+/* ========================================================================== */
 /* Prompt Input Listeners                                                     */
 /* ========================================================================== */
 

--- a/providers/openai.js
+++ b/providers/openai.js
@@ -63,19 +63,43 @@ class OpenAi extends Provider {
 
         `);
 			setTimeout(() => {
-				this.getWebview().executeJavaScript(`
-          // Get the root element
-          const root = document.querySelector(':root');
+        // Get the current dark mode setting from the store
+        const isDarkMode = store.get('darkMode', false);
 
-          // Set the color-scheme CSS variable
-          root.style.setProperty('--color-scheme', 'dark');
-
-          // Add the .dark class to the body
-          document.body.classList.add('dark');
-
-          `);
-			}, 0);
+        // Toggle dark mode based on the current setting
+        this.toggleDarkMode(isDarkMode);
+      }, 300);
 		});
+	}
+
+  static toggleDarkMode(isDarkMode) {
+		if (isDarkMode) {
+			// Add code to enable dark mode
+			this.getWebview().executeJavaScript(`
+				// Get the root element
+				const root = document.querySelector(':root');
+
+				// Set the color-scheme CSS variable
+				root.style.setProperty('--color-scheme', 'dark');
+
+				// Add the .dark class to the body
+				document.body.classList.add('dark');
+        document.body.classList.remove('light');
+			`);
+		} else {
+			// Add code to disable dark mode
+			this.getWebview().executeJavaScript(`
+				// Get the root element
+				const root = document.querySelector(':root');
+
+				// Remove the color-scheme CSS variable
+				root.style.setProperty('--color-scheme', 'light');
+
+				// Remove the .dark class from the body
+        document.body.classList.add('light');
+				document.body.classList.remove('dark');
+			`);
+		}
 	}
 
 	static isEnabled() {


### PR DESCRIPTION
So far, I've only added changes to `index.js`, `interface.js`, and `providers/openai.js`. I've tested with ChatGPT and the current implementation works well for this provider. Other providers have not yet been added.

You can pull down my feature branch and build via `npm run make` and test with the changes from this PR to verify.

**Stuff I could use some pointers/help on:**
It seems that there is a somewhat different implementation for dark mode for each provider. Thus, I'll need to figure out the required changes for each. I could use some help with this part if someone wants to lend a hand or provide some guidance.

Within my browser's DevTools, where would I look to find out the provider-specific changes that get applied when a user toggles on dark mode within the browser?

I'm also open to suggestions for how to improve this!

**TODO:**
* Add keybinding for dark mode toggle (in progress)
* Figure out equivalent changes to make to each of the following providers (could use some help with this part):
  * `providers/bard.js`
  * `providers/bing.js`
  * `providers/claude.js`
  * `providers/claude2.js`
  * `providers/huggingchat.js`
  * `providers/oobabooga.js`
  * `providers/perplexity.js`
  * `providers/phind.js`
  * `providers/smol.js`

Related open GH issue: https://github.com/smol-ai/menubar/issues/95