### PR TITLE
feat(index) menubar stays open in development for debugging

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,6 +90,7 @@ app.on('ready', () => {
 			},
 			width: store.get('isFullscreen', false) ? width : 1200,
 			height: 750,
+			focusable: process.env.NODE_ENV !== 'development'
 		},
 		tray,
 		showOnAllWorkspaces: false,

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ app.on('ready', () => {
 			},
 			width: store.get('isFullscreen', false) ? width : 1200,
 			height: 750,
-			focusable: process.env.NODE_ENV !== 'development'
+			focusable: process.env.NODE_ENV !== 'development',
 		},
 		tray,
 		showOnAllWorkspaces: false,


### PR DESCRIPTION
With this change, menubar will no longer dismiss when it loses focus in development mode, which means the webview-specific dev tools windows will also stay open and be interactive! So this is a small fix that will make debugging a lot more pleasant.