### PR TITLE
Dev mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,6 +90,7 @@ app.on('ready', () => {
 			},
 			width: store.get('isFullscreen', false) ? width : 1200,
 			height: 750,
+			focusable: process.env.NODE_ENV !== 'development'
 		},
 		tray,
 		showOnAllWorkspaces: false,

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ app.on('ready', () => {
 			},
 			width: store.get('isFullscreen', false) ? width : 1200,
 			height: 750,
-			focusable: process.env.NODE_ENV !== 'development'
+			// focusable: process.env.NODE_ENV !== 'development'
 		},
 		tray,
 		showOnAllWorkspaces: false,

--- a/index.js
+++ b/index.js
@@ -415,13 +415,6 @@ app.on('ready', () => {
 		});
 	});
 
-	if (process.platform == 'darwin') {
-		// restore focus to previous app on hiding
-		mb.on('after-hide', () => {
-			mb.app.hide();
-		});
-	}
-
 	// open links in new window
 	// app.on("web-contents-created", (event, contents) => {
 	//   contents.on("will-navigate", (event, navigationUrl) => {


### PR DESCRIPTION
Better version of "dev mode":
- Menubar won't auto dismiss when it loses focus in dev mode, and neither will webview developer tools windows
- Menubar will still dismiss if you manually use the keyboard shortcut or left click the menubar icon to hide
- Added an "in dev mode" notice to the context menu to make it more noticeable when you're in dev mode vs. production