### PR TITLE
Resolve chat window focus issue by setting showOnAllWorkspaces to true

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ app.on('ready', () => {
 			height: 750,
 		},
 		tray,
-		showOnAllWorkspaces: false,
+		showOnAllWorkspaces: true,
 		preloadWindow: true,
 		showDockIcon: true,
 		icon: image,


### PR DESCRIPTION
Hi there, 
I found this window-focusing issue(the chat window has always opened on the first desktop, not where the user currently is) from an issue. 

So I try to do this simple adjustment to modify this parameter `showOnAllWorkspaces` to `true`. It should allow users to open a chat window without being sent back to the first desktop.

hope this can help 🙂

Related to #115